### PR TITLE
Fix invariant decimal parsing

### DIFF
--- a/HomeFinancial.OfxParser/OfxParser.cs
+++ b/HomeFinancial.OfxParser/OfxParser.cs
@@ -94,7 +94,10 @@ public class OfxParser : IOfxParser
         decimal? ParseAmount(string amountString)
         {
             return !string.IsNullOrEmpty(amountString) &&
-                   decimal.TryParse(amountString.Replace('.', ','), 
+                   decimal.TryParse(
+                       amountString,
+                       NumberStyles.Number,
+                       CultureInfo.InvariantCulture,
                        out var amount)
                 ? amount
                 : null;


### PR DESCRIPTION
## Summary
- handle OFX amounts using invariant culture so numbers parse correctly on any locale

## Testing
- `dotnet test --no-build --verbosity normal` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68587726f41c8325824909697fb67b31